### PR TITLE
Fix crash on inserting wrong ink type

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ minecraft_version=1.20.1
 loader_version=0.16.10
 
 # Mod Properties
-mod_version=1.0.1
+mod_version=1.0.2
 maven_group=vg.skye.appspec
 archives_base_name=appspec
 

--- a/src/main/java/vg/skye/appspec/InkExportStrategy.java
+++ b/src/main/java/vg/skye/appspec/InkExportStrategy.java
@@ -32,14 +32,17 @@ public class InkExportStrategy implements StackExportStrategy {
         if (!(be instanceof InkStorageBlockEntity<?>))
             return 0;
         var storage = ((InkStorageBlockEntity<?>) be).getEnergyStorage();
+        var color = ((InkKey) what).getColor();
+        if (!storage.accepts(color))
+            return 0;
 
-        var capacity = storage.getRoom(((InkKey) what).getColor());
+        var capacity = storage.getRoom(color);
         var insertable = Math.min(maxAmount, capacity);
         var extracted = StorageHelper.poweredExtraction(context.getEnergySource(),
                 context.getInternalStorage().getInventory(), what, insertable, context.getActionSource(),
                 Actionable.MODULATE);
         if (extracted > 0) {
-            var inserted = storage.addEnergy(((InkKey) what).getColor(), extracted);
+            var inserted = storage.addEnergy(color, extracted);
             if (extracted != inserted) {
                 AppliedSpectrometry.LOGGER.error("Overextracted ink? (Extracted {}, inserted {})", extracted, inserted);
             }
@@ -58,13 +61,16 @@ public class InkExportStrategy implements StackExportStrategy {
         if (!(be instanceof InkStorageBlockEntity<?>))
             return 0;
         var storage = ((InkStorageBlockEntity<?>) be).getEnergyStorage();
+        var color = ((InkKey) what).getColor();
+        if (!storage.accepts(color))
+            return 0;
 
         if (mode == Actionable.SIMULATE) {
-            var capacity = storage.getRoom(((InkKey) what).getColor());
+            var capacity = storage.getRoom(color);
             return Math.min(maxAmount, capacity);
         }
 
-        var inserted = storage.addEnergy(((InkKey) what).getColor(), maxAmount);
+        var inserted = storage.addEnergy(color, maxAmount);
         ((InkStorageBlockEntity<?>) be).setInkDirty();
         be.setChanged();
         return inserted;

--- a/src/main/java/vg/skye/appspec/InkStorageStrategy.java
+++ b/src/main/java/vg/skye/appspec/InkStorageStrategy.java
@@ -46,10 +46,13 @@ public class InkStorageStrategy implements ExternalStorageStrategy {
         public long insert(AEKey what, long amount, Actionable mode, IActionSource source) {
             if (!(what instanceof InkKey))
                 return 0;
+            var color = ((InkKey) what).getColor();
+            if (!storage.getEnergyStorage().accepts(color))
+                return 0;
             if (mode == Actionable.SIMULATE) {
-                return Math.min(amount, storage.getEnergyStorage().getRoom(((InkKey) what).getColor()));
+                return Math.min(amount, storage.getEnergyStorage().getRoom(color));
             }
-            var inserted = storage.getEnergyStorage().addEnergy(((InkKey) what).getColor(), amount);
+            var inserted = storage.getEnergyStorage().addEnergy(color, amount);
             if (inserted > 0) {
                 storage.setInkDirty();
                 ((BlockEntity) storage).setChanged();


### PR DESCRIPTION
Fixes #5

Turns out the export bus can also just outright crash the entire server. And if you do that where someone spawns OR in forceloaded chunks... hello crashlooping