### PR TITLE
Fix ink duplication bug, fix log spam

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ minecraft_version=1.20.1
 loader_version=0.16.10
 
 # Mod Properties
-mod_version=1.0.1
+mod_version=1.0.2
 maven_group=vg.skye.appspec
 archives_base_name=appspec
 

--- a/src/main/java/vg/skye/appspec/BasicCellInventoryInkStorage.java
+++ b/src/main/java/vg/skye/appspec/BasicCellInventoryInkStorage.java
@@ -31,7 +31,8 @@ public class BasicCellInventoryInkStorage implements InkStorage {
 
     @Override
     public long addEnergy(InkColor color, long amount) {
-        return inventory.insert(new InkKey(color), amount, Actionable.MODULATE, IActionSource.empty());
+        var inserted = inventory.insert(new InkKey(color), amount, Actionable.MODULATE, IActionSource.empty());
+        return amount - inserted;
     }
 
     @Override

--- a/src/main/java/vg/skye/appspec/InkExportStrategy.java
+++ b/src/main/java/vg/skye/appspec/InkExportStrategy.java
@@ -36,19 +36,23 @@ public class InkExportStrategy implements StackExportStrategy {
         if (!storage.accepts(color))
             return 0;
 
-        var capacity = storage.getRoom(color);
-        var insertable = Math.min(maxAmount, capacity);
+        var remainingCapacity = storage.getRoom(color);
+        var insertable = Math.min(maxAmount, remainingCapacity);
         var extracted = StorageHelper.poweredExtraction(context.getEnergySource(),
                 context.getInternalStorage().getInventory(), what, insertable, context.getActionSource(),
                 Actionable.MODULATE);
-        if (extracted > 0) {
-            var inserted = storage.addEnergy(color, extracted);
-            if (extracted != inserted) {
-                AppliedSpectrometry.LOGGER.error("Overextracted ink? (Extracted {}, inserted {})", extracted, inserted);
-            }
-            ((InkStorageBlockEntity<?>) be).setInkDirty();
-            be.setChanged();
+
+        if (extracted == 0) {
+            return 0;
         }
+
+        var overflow = InkWorkaround.addEnergyBugfix(storage, color, extracted);
+        var inserted = extracted - overflow;
+        if (extracted != inserted) {
+            AppliedSpectrometry.LOGGER.error("Ink over-extracted despite checking capacity? (Extracted {}, inserted {})", extracted, inserted);
+        }
+        ((InkStorageBlockEntity<?>) be).setInkDirty();
+        be.setChanged();
         return extracted;
     }
 
@@ -70,7 +74,8 @@ public class InkExportStrategy implements StackExportStrategy {
             return Math.min(maxAmount, capacity);
         }
 
-        var inserted = storage.addEnergy(color, maxAmount);
+        var overflow = InkWorkaround.addEnergyBugfix(storage, color, maxAmount);
+        var inserted = maxAmount - overflow;
         ((InkStorageBlockEntity<?>) be).setInkDirty();
         be.setChanged();
         return inserted;

--- a/src/main/java/vg/skye/appspec/InkExportStrategy.java
+++ b/src/main/java/vg/skye/appspec/InkExportStrategy.java
@@ -32,14 +32,17 @@ public class InkExportStrategy implements StackExportStrategy {
         if (!(be instanceof InkStorageBlockEntity<?>))
             return 0;
         var storage = ((InkStorageBlockEntity<?>) be).getEnergyStorage();
+        var color = ((InkKey) what).getColor();
+        if (!storage.accepts(color))
+            return 0;
 
-        var capacity = storage.getRoom(((InkKey) what).getColor());
+        var capacity = storage.getRoom(color);
         var insertable = Math.min(maxAmount, capacity);
         var extracted = StorageHelper.poweredExtraction(context.getEnergySource(),
                 context.getInternalStorage().getInventory(), what, insertable, context.getActionSource(),
                 Actionable.MODULATE);
         if (extracted > 0) {
-            var inserted = storage.addEnergy(((InkKey) what).getColor(), extracted);
+            var inserted = storage.addEnergy(color, extracted);
             if (extracted != inserted) {
                 AppliedSpectrometry.LOGGER.error("Overextracted ink? (Extracted {}, inserted {})", extracted, inserted);
             }
@@ -58,13 +61,16 @@ public class InkExportStrategy implements StackExportStrategy {
         if (!(be instanceof InkStorageBlockEntity<?>))
             return 0;
         var storage = ((InkStorageBlockEntity<?>) be).getEnergyStorage();
+        var color = ((InkKey) what).getColor();
+        if (!storage.accepts(color))
+            return 0;
 
         if (mode == Actionable.SIMULATE) {
-            var capacity = storage.getRoom(((InkKey) what).getColor());
+            var capacity = storage.getRoom(color);
             return Math.min(maxAmount, capacity);
         }
 
-        var inserted = storage.addEnergy(((InkKey) what).getColor(), maxAmount);
+        var inserted = storage.addEnergy(color, maxAmount);
         ((InkStorageBlockEntity<?>) be).setInkDirty();
         be.setChanged();
         return inserted;

--- a/src/main/java/vg/skye/appspec/InkImportStrategy.java
+++ b/src/main/java/vg/skye/appspec/InkImportStrategy.java
@@ -37,17 +37,19 @@ public class InkImportStrategy implements StackImportStrategy {
         var storage = ((InkStorageBlockEntity<?>) be).getEnergyStorage();
         for (InkColor inkColor : storage.getEnergy().keySet()) {
             var key = new InkKey(inkColor);
-            if (context.isInFilter(key) != context.isInverted()) {
-                var extracted = storage.drainEnergy(inkColor, maxTransfer);
-                var inserted = context.getInternalStorage().getInventory().insert(key, extracted, Actionable.MODULATE, context.getActionSource());
-                var toRefund = extracted - inserted;
-                var refunded = storage.addEnergy(inkColor, toRefund);
-                if (refunded != toRefund) {
-                    AppliedSpectrometry.LOGGER.error("Failed to correctly refund overextracted ink? (Wanted to refund {}, refunded {})", toRefund, refunded);
-                }
-                maxTransfer -= inserted;
-                transferred += inserted;
+            if (context.isInFilter(key) == context.isInverted()) {
+                continue;
             }
+
+            var extracted = storage.drainEnergy(inkColor, maxTransfer);
+            var inserted = context.getInternalStorage().getInventory().insert(key, extracted, Actionable.MODULATE, context.getActionSource());
+            var toRefund = extracted - inserted;
+            var refunded = toRefund - InkWorkaround.addEnergyBugfix(storage, inkColor, toRefund);
+            if (refunded != toRefund) {
+                AppliedSpectrometry.LOGGER.error("Failed to correctly refund over-extracted ink? (Wanted to refund {}, refunded {})", toRefund, refunded);
+            }
+            maxTransfer -= inserted;
+            transferred += inserted;
         }
         ((InkStorageBlockEntity<?>) be).setInkDirty();
         be.setChanged();

--- a/src/main/java/vg/skye/appspec/InkItemStrategy.java
+++ b/src/main/java/vg/skye/appspec/InkItemStrategy.java
@@ -15,12 +15,13 @@ public class InkItemStrategy implements ContainerItemStrategy<InkKey, ItemStack>
         if (stack.isEmpty()) {
             return null;
         }
-        if (stack.getItem() instanceof InkStorageItem<?> item) {
-            var colors = item.getEnergyStorage(stack).getEnergy();
-            for (var entry : colors.entrySet()) {
-                if (entry.getValue() != 0) {
-                    return new GenericStack(new InkKey(entry.getKey()), entry.getValue());
-                }
+        if (!(stack.getItem() instanceof InkStorageItem<?> item)) {
+            return null;
+        }
+        var colors = item.getEnergyStorage(stack).getEnergy();
+        for (var entry : colors.entrySet()) {
+            if (entry.getValue() != 0) {
+                return new GenericStack(new InkKey(entry.getKey()), entry.getValue());
             }
         }
         return null;
@@ -32,10 +33,10 @@ public class InkItemStrategy implements ContainerItemStrategy<InkKey, ItemStack>
         if (stack.isEmpty() || stack.getCount() != 1) {
             return null;
         }
-        if (stack.getItem() instanceof InkStorageItem<?>) {
-            return stack;
+        if (!(stack.getItem() instanceof InkStorageItem<?>)) {
+            return null;
         }
-        return null;
+        return stack;
     }
 
     @Override
@@ -44,10 +45,10 @@ public class InkItemStrategy implements ContainerItemStrategy<InkKey, ItemStack>
         if (stack.isEmpty() || stack.getCount() != 1) {
             return null;
         }
-        if (stack.getItem() instanceof InkStorageItem<?>) {
-            return stack;
+        if (!(stack.getItem() instanceof InkStorageItem<?>)) {
+            return null;
         }
-        return null;
+        return stack;
     }
 
     @Override
@@ -55,16 +56,16 @@ public class InkItemStrategy implements ContainerItemStrategy<InkKey, ItemStack>
         if (context.isEmpty() || context.getCount() != 1) {
             return 0;
         }
-        if (context.getItem() instanceof InkStorageItem<?> item) {
-            var colors = item.getEnergyStorage(context);
-            if (mode == Actionable.SIMULATE) {
-                return Math.min(colors.getEnergy(what.getColor()), amount);
-            }
-            var drained = colors.drainEnergy(what.getColor(), amount);
-            item.setEnergyStorage(context, colors);
-            return drained;
+        if (!(context.getItem() instanceof InkStorageItem<?> item)) {
+            return 0;
         }
-        return 0;
+        var colors = item.getEnergyStorage(context);
+        if (mode == Actionable.SIMULATE) {
+            return Math.min(colors.getEnergy(what.getColor()), amount);
+        }
+        var drained = colors.drainEnergy(what.getColor(), amount);
+        item.setEnergyStorage(context, colors);
+        return drained;
     }
 
     @Override
@@ -72,16 +73,16 @@ public class InkItemStrategy implements ContainerItemStrategy<InkKey, ItemStack>
         if (context.isEmpty() || context.getCount() != 1) {
             return 0;
         }
-        if (context.getItem() instanceof InkStorageItem<?> item) {
-            var colors = item.getEnergyStorage(context);
-            if (mode == Actionable.SIMULATE) {
-                return Math.min(colors.getRoom(what.getColor()), amount);
-            }
-            var inserted = colors.addEnergy(what.getColor(), amount);
-            item.setEnergyStorage(context, colors);
-            return inserted;
+        if (!(context.getItem() instanceof InkStorageItem<?> item)) {
+            return 0;
         }
-        return 0;
+        var colors = item.getEnergyStorage(context);
+        if (mode == Actionable.SIMULATE) {
+            return Math.min(colors.getRoom(what.getColor()), amount);
+        }
+        var overflow = InkWorkaround.addEnergyBugfix(colors, what.getColor(), amount);
+        item.setEnergyStorage(context, colors);
+        return amount - overflow;
     }
 
     @Override

--- a/src/main/java/vg/skye/appspec/InkStorageStrategy.java
+++ b/src/main/java/vg/skye/appspec/InkStorageStrategy.java
@@ -46,10 +46,13 @@ public class InkStorageStrategy implements ExternalStorageStrategy {
         public long insert(AEKey what, long amount, Actionable mode, IActionSource source) {
             if (!(what instanceof InkKey))
                 return 0;
+            var color = ((InkKey) what).getColor();
+            if (!storage.getEnergyStorage().accepts(color))
+                return 0;
             if (mode == Actionable.SIMULATE) {
-                return Math.min(amount, storage.getEnergyStorage().getRoom(((InkKey) what).getColor()));
+                return Math.min(amount, storage.getEnergyStorage().getRoom(color));
             }
-            var inserted = storage.getEnergyStorage().addEnergy(((InkKey) what).getColor(), amount);
+            var inserted = storage.getEnergyStorage().addEnergy(color, amount);
             if (inserted > 0) {
                 storage.setInkDirty();
                 ((BlockEntity) storage).setChanged();

--- a/src/main/java/vg/skye/appspec/InkStorageStrategy.java
+++ b/src/main/java/vg/skye/appspec/InkStorageStrategy.java
@@ -52,7 +52,8 @@ public class InkStorageStrategy implements ExternalStorageStrategy {
             if (mode == Actionable.SIMULATE) {
                 return Math.min(amount, storage.getEnergyStorage().getRoom(color));
             }
-            var inserted = storage.getEnergyStorage().addEnergy(color, amount);
+            var overflow = storage.getEnergyStorage().addEnergy(color, amount);
+            var inserted = amount - overflow;
             if (inserted > 0) {
                 storage.setInkDirty();
                 ((BlockEntity) storage).setChanged();

--- a/src/main/java/vg/skye/appspec/InkWorkaround.java
+++ b/src/main/java/vg/skye/appspec/InkWorkaround.java
@@ -1,0 +1,15 @@
+package vg.skye.appspec;
+
+import de.dafuqs.spectrum.api.energy.InkStorage;
+import de.dafuqs.spectrum.api.energy.color.InkColor;
+import de.dafuqs.spectrum.api.energy.storage.SingleInkStorage;
+
+public class InkWorkaround {
+    // Returns the overflow of trying to insert ink into the item
+    // SingleInkStorage.addEnergy incorrectly returns the amount of ink stored instead of overflow when item (e.g. flask) is empty
+    public static long addEnergyBugfix(InkStorage storage, InkColor color, long amount) {
+        var overflowBug = storage instanceof SingleInkStorage && storage.isEmpty();
+        var overflow = storage.addEnergy(color, amount);
+        return overflowBug ? 0 : overflow;
+    }
+}


### PR DESCRIPTION
Spectrum's `addEnergy` actually returns overflow... except for when it's a single ink type containing item and it was empty. Makes it much less easy to notice

Fixes #4 